### PR TITLE
[WIP]New inbox for streaming

### DIFF
--- a/stan.go
+++ b/stan.go
@@ -282,7 +282,7 @@ func Connect(stanClusterID, clientID string, options ...Option) (Conn, error) {
 	}
 
 	// Create a heartbeat inbox
-	hbInbox := nats.NewClientInbox(fmt.Sprintf("%s.HeartBeat",clientID))
+	hbInbox := nats.NewClientInbox(fmt.Sprintf("%s.HeartBeat", clientID))
 	var err error
 	if c.hbSubscription, err = c.nc.Subscribe(hbInbox, c.processHeartBeat); err != nil {
 		c.Close()
@@ -292,14 +292,14 @@ func Connect(stanClusterID, clientID string, options ...Option) (Conn, error) {
 	// Prepare a subscription on ping responses, even if we are not
 	// going to need it, so that if that fails, it fails before initiating
 	// a connection.
-	pingSub, err := c.nc.Subscribe(nats.NewClientInbox(fmt.Sprintf("%s.Ping",clientID)), c.processPingResponse)
+	pingSub, err := c.nc.Subscribe(nats.NewClientInbox(fmt.Sprintf("%s.Ping", clientID)), c.processPingResponse)
 	if err != nil {
 		c.Close()
 		return nil, err
 	}
 
 	// Send Request to discover the cluster
-	discoverSubject := c.opts.DiscoverPrefix + "." + stanClusterID+"."+clientID
+	discoverSubject := c.opts.DiscoverPrefix + "." + stanClusterID + "." + clientID
 	req := &pb.ConnectRequest{
 		ClientID:       clientID,
 		HeartbeatInbox: hbInbox,
@@ -337,7 +337,7 @@ func Connect(stanClusterID, clientID string, options ...Option) (Conn, error) {
 	c.closeRequests = cr.CloseRequests
 
 	// Setup the ACK subscription
-	c.ackSubject = DefaultACKPrefix + "." + clientID +"." + nuid.Next()
+	c.ackSubject = DefaultACKPrefix + "." + clientID + "." + nuid.Next()
 	if c.ackSubscription, err = c.nc.Subscribe(c.ackSubject, c.processAck); err != nil {
 		c.Close()
 		return nil, err

--- a/stan.go
+++ b/stan.go
@@ -282,7 +282,7 @@ func Connect(stanClusterID, clientID string, options ...Option) (Conn, error) {
 	}
 
 	// Create a heartbeat inbox
-	hbInbox := nats.NewInbox()
+	hbInbox := nats.NewClientInbox(fmt.Sprintf("%s.HeartBeat",clientID))
 	var err error
 	if c.hbSubscription, err = c.nc.Subscribe(hbInbox, c.processHeartBeat); err != nil {
 		c.Close()
@@ -292,14 +292,14 @@ func Connect(stanClusterID, clientID string, options ...Option) (Conn, error) {
 	// Prepare a subscription on ping responses, even if we are not
 	// going to need it, so that if that fails, it fails before initiating
 	// a connection.
-	pingSub, err := c.nc.Subscribe(nats.NewInbox(), c.processPingResponse)
+	pingSub, err := c.nc.Subscribe(nats.NewClientInbox(fmt.Sprintf("%s.Ping",clientID)), c.processPingResponse)
 	if err != nil {
 		c.Close()
 		return nil, err
 	}
 
 	// Send Request to discover the cluster
-	discoverSubject := c.opts.DiscoverPrefix + "." + stanClusterID
+	discoverSubject := c.opts.DiscoverPrefix + "." + stanClusterID+"."+clientID
 	req := &pb.ConnectRequest{
 		ClientID:       clientID,
 		HeartbeatInbox: hbInbox,
@@ -337,7 +337,7 @@ func Connect(stanClusterID, clientID string, options ...Option) (Conn, error) {
 	c.closeRequests = cr.CloseRequests
 
 	// Setup the ACK subscription
-	c.ackSubject = DefaultACKPrefix + "." + nuid.Next()
+	c.ackSubject = DefaultACKPrefix + "." + clientID +"." + nuid.Next()
 	if c.ackSubscription, err = c.nc.Subscribe(c.ackSubject, c.processAck); err != nil {
 		c.Close()
 		return nil, err


### PR DESCRIPTION
New clients inboxes. Necessary changes to integrate access control in NATS streaming
In new version use clients section in config for automatically allow subscribe and publish to "_INBOX._CLIENTS.ClientIdXYZ.>". Not use "_INBOX.>" publish and subscribe with clients. "_INBOX.>" will be allowed to write and read other _INBOX._CLIENTS.

go-nats client pull request https://github.com/nats-io/go-nats/pull/441
gnatsd in bfoxstudio repo https://github.com/bfoxstudio/gnatsd/pull/1